### PR TITLE
Fix cache serialization and config errors

### DIFF
--- a/utils/helpers/helpers.py
+++ b/utils/helpers/helpers.py
@@ -152,7 +152,7 @@ def cache_with_invalidation(func: Optional[Callable] = None, *, ttl: int = 3600)
 # ---------- Enhanced HTTP Cache ---------- TODO: This is unknown
 class EnhancedJSONEncoder(json.JSONEncoder):
     """Extend JSONEncoder with common non-JSON types handling."""
-    def _default(self, obj: Any) -> Any | None:
+    def default(self, obj: Any) -> Any | None:
         # datetimes -> ISO8601 string
         if isinstance(obj, (dt.datetime, dt.date, dt.time)):
             # Use ISO format; datetimes preserve timezone if present
@@ -756,6 +756,11 @@ def load_results() -> List[Dict[str, Any]]:
     cache_key = "load_results:default"
     # File-based data; skip remote cache and always read
     try:
+        # Ensure we have the config attribute
+        if not hasattr(config, 'EXAM_RESULTS_INDEX_FILE'):
+            log.critical(action="config_error", trace_info="load_results", 
+                        message="EXAM_RESULTS_INDEX_FILE not found in config", secure=False)
+            return []
         with open(config.EXAM_RESULTS_INDEX_FILE, 'r') as f:
             data = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
@@ -765,6 +770,11 @@ def load_results() -> List[Dict[str, Any]]:
 
 def save_results(data: List[Dict[str, Any]]) -> None:
     """Save exam results with atomic write and cache invalidation."""
+    # Ensure we have the config attribute
+    if not hasattr(config, 'EXAM_RESULTS_INDEX_FILE'):
+        log.critical(action="config_error", trace_info="save_results", 
+                    message="EXAM_RESULTS_INDEX_FILE not found in config", secure=False)
+        return
     temp_file = config.EXAM_RESULTS_INDEX_FILE + '.tmp'
     try:
         with open(temp_file, 'w') as f:
@@ -782,6 +792,11 @@ def load_notices() -> List[Dict[str, Any]]:
     cache_key = "load_notices:default"
     # File-based data; skip remote cache and always read
     try:
+        # Ensure we have the config attribute
+        if not hasattr(config, 'NOTICES_INDEX_FILE'):
+            log.critical(action="config_error", trace_info="load_notices", 
+                        message="NOTICES_INDEX_FILE not found in config", secure=False)
+            return []
         with open(config.NOTICES_INDEX_FILE, 'r') as f:
             data = json.load(f)
     except json.JSONDecodeError:
@@ -796,6 +811,11 @@ def load_notices() -> List[Dict[str, Any]]:
 
 def save_notices(data: List[Dict[str, Any]]) -> None:
     """Save notices with atomic write and cache invalidation."""
+    # Ensure we have the config attribute
+    if not hasattr(config, 'NOTICES_INDEX_FILE'):
+        log.critical(action="config_error", trace_info="save_notices", 
+                    message="NOTICES_INDEX_FILE not found in config", secure=False)
+        return
     temp_file = config.NOTICES_INDEX_FILE + '.tmp'
     try:
         with open(temp_file, 'w') as f:


### PR DESCRIPTION
Fixes JSON serialization for datetime objects and adds defensive checks for missing config attributes.

The `EnhancedJSONEncoder` was using `_default` instead of `default`, which prevented proper serialization of datetime objects. Defensive `hasattr` checks were also added to `load_` and `save_` functions for notices and exam results to prevent crashes when config attributes are not found.

---
<a href="https://cursor.com/background-agent?bcId=bc-877a1a2b-f06c-4ef0-ba46-68a02137b825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-877a1a2b-f06c-4ef0-ba46-68a02137b825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

