### PR TITLE
Migrate html files to fastapi

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -188,3 +188,24 @@ If issues arise:
 - [FastAPI Documentation](https://fastapi.tiangolo.com/)
 - [Migration Guide](https://fastapi.tiangolo.com/tutorial/)
 - [Pydantic Documentation](https://pydantic-docs.helpmanual.io/)
+
+### User Sessions
+
+1. **Session Storage**: Using client-side signed cookies (itsdangerous)
+2. **No server sessions**: All session data in encrypted cookies
+3. **Session keys**: admin_logged_in, admin_username, user_id, etc.
+
+### Templates and Static Files
+
+1. **Template Engine**: Using Jinja2Templates from FastAPI
+2. **Template Functions**:
+   - `url_for()`: Custom implementation in `fastapi_helpers.py` that maps route names to URLs
+   - `get_flashed_messages()`: Returns empty list (placeholder for future implementation)
+   - `csrf_token()`: Returns empty string (CSRF handled differently in FastAPI)
+3. **Route Names**: Added explicit names to all routes for template url_for compatibility:
+   - Web routes: home, donate, contact, privacy, terms
+   - Admin routes: admin_dashboard, login, admin_logout, view_logs, members, etc.
+   - API routes: manage_account
+4. **Static Files**: Mounted at /static and /uploads using StaticFiles
+
+## Security Considerations

--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -114,3 +114,42 @@ This PR migrates the Madrasa Management System from Quart to FastAPI while prese
 ## Related Documentation
 
 See `MIGRATION_NOTES.md` for detailed technical notes about the migration.
+
+## Testing Recommendations
+
+1. **Unit Tests**: Update test suite to use httpx.AsyncClient
+2. **Integration Tests**: Test database connections and Redis cache
+3. **Load Testing**: Verify performance with uvicorn workers
+4. **Security Testing**: Validate authentication and authorization flows
+
+## Template Migration
+
+### Changes Made to Support FastAPI Templates
+
+1. **Route Names Added**: All routes now have explicit names for template `url_for()` compatibility
+   - Admin routes: admin_dashboard, login, admin_logout, view_logs, logs_data, info_page, info_data_admin, exam_results, members, notice_page, routines, events, madrasa_pictures, exams, interactions, power_management
+   - Web routes: home, donate, contact, privacy, terms
+   - API routes: manage_account
+
+2. **Template Helper Functions**: Implemented in `utils/helpers/fastapi_helpers.py`
+   - `url_for()`: Custom mapping function that handles static files, admin routes, API routes, and web routes
+   - `get_flashed_messages()`: Returns empty list (placeholder)
+   - `csrf_token()`: Returns empty string (CSRF handled via middleware)
+
+3. **Template Updates**:
+   - Fixed incorrect route reference: Changed `api.pay_sslcommerz` to `api.process_payment` in donate.html
+   - All templates now use the centralized Jinja2Templates instance
+   - Template context includes request object for all renders
+
+4. **No Changes Required**: Templates already use `{{ url_for(...) }}` syntax which works with our custom implementation
+
+### Template Testing Checklist
+
+- [ ] All admin pages render correctly
+- [ ] Navigation links work properly
+- [ ] Forms submit to correct endpoints
+- [ ] Static assets (CSS, JS, images) load correctly
+- [ ] Flash messages display when implemented
+- [ ] CSRF tokens are included in forms
+
+## Deployment Checklist

--- a/routes/admin_routes/v1/auth_admin.py
+++ b/routes/admin_routes/v1/auth_admin.py
@@ -20,9 +20,10 @@ class LoginForm(BaseModel):
     password: str
     recaptcha_response: Optional[str] = None
 
-@admin_routes.get('/login', response_class=HTMLResponse)
+# ─── Login Page ─────────────────────────────────────────────────
+@admin_routes.get('/login', response_class=HTMLResponse, name="login")
 @rate_limit(max_requests=50, window=300)
-async def login_get(request: Request):
+async def login_page(request: Request):
     # See for test mode
     test = True if config.is_testing() else False
     
@@ -40,9 +41,10 @@ async def login_get(request: Request):
         "test": test
     })
 
+# ─── Login Handler ──────────────────────────────────────────────
 @admin_routes.post('/login')
 @rate_limit(max_requests=50, window=300)
-async def login_post(
+async def login(
     request: Request,
     username: str = Form(...),
     password: str = Form(...),
@@ -159,7 +161,8 @@ async def login_post(
         }
     )
 
-@admin_routes.get('/logout')
+# ─── Logout ─────────────────────────────────────────────────────
+@admin_routes.get('/logout', name="admin_logout")
 async def admin_logout(request: Request, client_info: ClientInfo = Depends(get_client_info)):
     ip_address = client_info.ip_address
     

--- a/routes/admin_routes/v1/auxiliary.py
+++ b/routes/admin_routes/v1/auxiliary.py
@@ -23,7 +23,8 @@ async def require_admin(request: Request):
 # Import session utilities for enhanced session management
 from utils.helpers.session_utils import require_admin_session, update_session_activity
 
-@admin_routes.get('/logs/data')
+# ─── Logs Data Endpoint ─────────────────────────────────────────
+@admin_routes.get('/logs/data', name="logs_data")
 @handle_async_errors
 async def logs_data(request: Request, is_admin: bool = Depends(require_admin)):
     # Get requested log file
@@ -48,7 +49,8 @@ async def logs_data(request: Request, is_admin: bool = Depends(require_admin)):
 
 
 
-@admin_routes.get('/info/data')
+# ─── Info Data Endpoint ─────────────────────────────────────────
+@admin_routes.get('/info/data', name="info_data_admin")
 @handle_async_errors
 async def info_data_admin(request: Request, is_admin: bool = Depends(require_admin)):
     if config.is_testing():

--- a/routes/admin_routes/v1/views.py
+++ b/routes/admin_routes/v1/views.py
@@ -17,6 +17,7 @@ from config import config
 import json, re, os, aiomysql, subprocess
 from functools import wraps
 from utils.helpers.helpers import require_csrf
+from typing import Optional
 
 # Use centralized templates instance
 from utils.helpers.fastapi_helpers import templates
@@ -38,7 +39,7 @@ _FORBIDDEN_RE = re.compile(
 
 # ------------- Root / Dashboard ----------------
 
-@admin_routes.get('/', response_class=HTMLResponse)
+@admin_routes.get('/', response_class=HTMLResponse, name="admin_dashboard")
 @admin_routes.post('/', response_class=HTMLResponse)
 @require_csrf
 @handle_async_errors
@@ -198,7 +199,7 @@ async def admin_dashboard(request: Request):
 # ------------------ Logs ---------------------
 
 
-@admin_routes.get('/logs', response_class=HTMLResponse)
+@admin_routes.get('/logs', response_class=HTMLResponse, name="view_logs")
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
 async def view_logs(request: Request):
@@ -236,7 +237,7 @@ async def view_logs(request: Request):
     return templates.TemplateResponse("admin/logs.html", {"request": request, "logs": logs})
 
 
-@admin_routes.get('/info', response_class=HTMLResponse)
+@admin_routes.get('/info', response_class=HTMLResponse, name="info_page")
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
 async def info_admin(request: Request):
@@ -261,7 +262,7 @@ async def info_admin(request: Request):
 
 # ------------------ Exam Results ------------------------
 
-@admin_routes.get('/exam_results', response_class=HTMLResponse)
+@admin_routes.get('/exam_results', response_class=HTMLResponse, name="exam_results")
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
 async def exam_results(request: Request):
@@ -341,7 +342,7 @@ async def exam_results(request: Request):
 
 # ------------------- Members --------------------------
 
-@admin_routes.get('/members', response_class=HTMLResponse)
+@admin_routes.get('/members', response_class=HTMLResponse, name="members")
 @admin_routes.post('/members', response_class=HTMLResponse)
 @require_csrf
 @handle_async_errors
@@ -441,7 +442,7 @@ async def members(request: Request):
 
 # ------------------- Notices -----------------------
 
-@admin_routes.get('/notice', response_class=HTMLResponse)
+@admin_routes.get('/notice', response_class=HTMLResponse, name="notice_page")
 @admin_routes.post('/notice', response_class=HTMLResponse)
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
@@ -513,7 +514,7 @@ async def notice_page(request: Request):
 
 # ------------------ Routine ----------------------
 
-@admin_routes.get('/routines', response_class=HTMLResponse)
+@admin_routes.get('/routines', response_class=HTMLResponse, name="routines")
 @admin_routes.post('/routines', response_class=HTMLResponse)
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
@@ -584,7 +585,7 @@ async def routines(request: Request):
 
 # -------------------- Event / Function ------------------------
 
-@admin_routes.get('/events', response_class=HTMLResponse)
+@admin_routes.get('/events', response_class=HTMLResponse, name="events")
 @admin_routes.post('/events', response_class=HTMLResponse)
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
@@ -662,7 +663,7 @@ async def events(request: Request):
 
 # ------------------- Madrasa Pictures ------------------------
 
-@admin_routes.get('/madrasa_pictures', response_class=HTMLResponse)
+@admin_routes.get('/madrasa_pictures', response_class=HTMLResponse, name="madrasa_pictures")
 @admin_routes.post('/madrasa_pictures', response_class=HTMLResponse)
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
@@ -728,7 +729,7 @@ async def madrasa_pictures(request: Request):
 
 # ---------------------- Exam -----------------------------
 
-@admin_routes.get('/admin/events/exams', response_class=HTMLResponse)
+@admin_routes.get('/admin/events/exams', response_class=HTMLResponse, name="exams")
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
 async def exams(request: Request):
@@ -888,7 +889,7 @@ async def exams(request: Request):
 
 #     return render_template('admin/payment_form.html', payment=payment, mode=mode)
 
-@admin_routes.get('/interactions', response_class=HTMLResponse)
+@admin_routes.get('/interactions', response_class=HTMLResponse, name="interactions")
 @handle_async_errors
 @rate_limit(max_requests=500, window=60)
 async def interactions(request: Request):
@@ -925,7 +926,7 @@ async def interactions(request: Request):
     return templates.TemplateResponse('admin/interactions.html', {"request": request, "interactions": rows, "sort": sort})
 
 
-@admin_routes.get('/power', response_class=HTMLResponse)
+@admin_routes.get('/power', response_class=HTMLResponse, name="power_management")
 @admin_routes.post('/power', response_class=HTMLResponse)
 @require_csrf
 @handle_async_errors

--- a/routes/api/v1/auth.py
+++ b/routes/api/v1/auth.py
@@ -698,7 +698,7 @@ async def reset_password(
         response, status = send_json_response(ERROR_MESSAGES['internal_error'], 500)
         return JSONResponse(content=response, status_code=status)
 
-@api.post("/account/{page_type}")
+@api.post("/account/{page_type}", name="manage_account")
 @rate_limit(max_requests=10, window=60)
 @handle_async_errors
 async def manage_account(

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -49,7 +49,7 @@
     <div class="col-12 col-md-4">
       <div class="card h-100 shadow-sm option-card" role="button"
            data-title="Other (SSLCommerz)"
-           data-url="{{ url_for('api.pay_sslcommerz') }}"
+           data-url="{{ url_for('api.process_payment') }}"
            data-info="Use your card / mobile banking"
            data-gateway="true">
         <div class="card-body text-center p-4">


### PR DESCRIPTION
Migrate HTML templates to FastAPI compatibility by assigning explicit route names and enhancing the custom `url_for` helper.

This PR addresses template rendering issues by ensuring `url_for` calls within Jinja2 templates correctly resolve to FastAPI routes. It assigns explicit names to all relevant routes and updates the custom `url_for` helper function to map these names to their corresponding URLs, preserving existing template logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0640908-33ab-4a84-b601-40ec8b07b863">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0640908-33ab-4a84-b601-40ec8b07b863">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

